### PR TITLE
Try fixing missing row number in xlsx outputs

### DIFF
--- a/crates/excel-rs-xlsx/src/sheet.rs
+++ b/crates/excel-rs-xlsx/src/sheet.rs
@@ -43,6 +43,8 @@ impl<'a, W: Write + Seek> Sheet<'a, W> {
 
     // TOOD: Use ShortVec over Vec for cell ID
     pub fn write_row(&mut self, data: Vec<&[u8]>) -> Result<()> {
+        self.current_row_num += 1;
+
         let mut final_vec = Vec::with_capacity(512 * data.len());
 
         // TODO: Proper Error Handling


### PR DESCRIPTION
This might fix #5 ?

I noticed this is being incremented at the start of the write_row function for the typed sheet, but not in here. I'm not sure why and will assume it was just a miss, since I can't tell where else this is being incremented.

https://github.com/carlvoller/excel-rs/blob/f2ca35707990625e56c570faf4646da2e6f79b21/crates/excel-rs-xlsx/src/typed_sheet.rs#L43-L49
